### PR TITLE
test a new event, closes #64

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -58,6 +58,18 @@ def simulateCoOp(plotList, numYears, pruneYear=None, growthPattern=None, strateg
             for species in species_list
         ]
 
+        start_year = datetime.datetime(2020, 1, 1)
+        end_year = datetime.datetime(2021, 1, 1)
+        events.append(
+            Event(
+                "catastrophic overfertilization",
+                impact=0.001,
+                scope={"type": "species", "def": "e14"},
+                start=start_year,
+                end=end_year,
+            )
+        )
+
         farm = Farm(plotList)
         thisYearsHarvest = predict_yield_for_farm(
             farm=farm,
@@ -117,10 +129,7 @@ def main(args):
     plt.axes(xlim=(mnYear, mxYear), ylim=(0, (mxHarvest + (mxHarvest * 0.10))))
     plt.plot(pltYears, pltHarvests, linewidth=4)
     plt.style.use("ggplot")
-    plt.title(
-        "Yield Forecast",
-        fontsize=(fsize * 1.25),
-    )
+    plt.title("Yield Forecast", fontsize=(fsize * 1.25))
     plt.xlabel("Year", fontsize=fsize)
     plt.xticks(pltYears, rotation=45)
     plt.ylabel("Total pounds of green coffee produced", fontsize=fsize)

--- a/src/cafe/farm.py
+++ b/src/cafe/farm.py
@@ -152,8 +152,8 @@ class Event:
             return True
         if not self.end:
             return True
-        age = self.age(current_time)
-        return age > 0 and current_time <= self.end
+        age_in_mins = self.mins(current_time)
+        return age_in_mins > 0 and current_time <= self.end
 
     def _check_scope(self, plot: Optional[Plot] = None):
         if isinstance(self.scope, bool):
@@ -270,12 +270,7 @@ def predict_yield_for_farm(
         try:
             c = find_config(name, configs)
             harvests.append(
-                predict_yield_for_plot(
-                    plot=p,
-                    config=c,
-                    events=events,
-                    time=time,
-                )
+                predict_yield_for_plot(plot=p, config=c, events=events, time=time)
             )
         except ValueError as v:
             _logger.warn(


### PR DESCRIPTION
this addresses the bug where comparisons of time failed due to the contract change with `self.age` returning a timedelta.